### PR TITLE
Allow rdoc to run without gem

### DIFF
--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -109,6 +109,8 @@ module RDoc
   def self.load_yaml
     begin
       gem 'psych'
+    rescue NameError => e # --disable-gems
+      raise unless e.name == :gem
     rescue Gem::LoadError
     end
 

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -10,6 +10,8 @@ require 'strscan'
 
 begin
   gem 'json'
+rescue NameError => e # --disable-gems
+  raise unless e.name == :gem
 rescue Gem::LoadError
 end
 


### PR DESCRIPTION
rdoc can live without gem (as it uses "require xxx" after
the "gem xxx"). However, when using "gem xxx" directly,
it generates a NameError exception when gem is not defined.
This happens when ruby is called with "--disable-gems" while
trying to use rdoc bundled with ruby source.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

I'm the current ruby maintainer for OpenWRT. As routers are very resource restricted,
it is interesting to split every software into small pieces, with minimum dependencies
between them. This patch allows a user to use "require 'rdoc'" even without gems installed.