### PR TITLE
Do not store full path in GZipped js files.

### DIFF
--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -170,7 +170,7 @@ class RDoc::Generator::JsonIndex
 
     Zlib::GzipWriter.open(outfile) do |gz|
       gz.mtime = File.mtime(search_index_file)
-      gz.orig_name = search_index_file.to_s
+      gz.orig_name = search_index_file.basename.to_s
       gz.write search_index
       gz.close
     end
@@ -188,7 +188,7 @@ class RDoc::Generator::JsonIndex
 
         Zlib::GzipWriter.open(outfile) do |gz|
           gz.mtime = File.mtime(dest)
-          gz.orig_name = dest.to_s
+          gz.orig_name = dest.basename.to_s
           gz.write data
           gz.close
         end


### PR DESCRIPTION
This cause issues in RPM packaged gems in Fedora, since the files, there appears full path with installation prefix, while in reality, they are later installed on different place. E.g. during package build of Hub [1], the documentation is generated into ```/builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch/usr/share/doc/hub``` directory, while the ```/builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch``` prefix is later on stripped when the resulting RPM is generated. This cause issues such as:

```
+ /usr/lib/rpm/check-buildroot
Binary file /builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch/usr/share/doc/hub/js/navigation.js.gz matches
Binary file /builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch/usr/share/doc/hub/js/search_index.js.gz matches
Binary file /builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch/usr/share/doc/hub/js/searcher.js.gz matches
Found '/builddir/build/BUILDROOT/hub-1.12.1-3.fc22.noarch' in installed files; aborting
error: Bad exit status from /var/tmp/rpm-tmp.hP0mLS (%install)
RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.hP0mLS (%install)
```

Aside from this particular issue, I really wonder why generation of the GZipped js files is not just optional. As far as I can say, they are not useful when the documentation is browsed just locally. In this case, it just consume more disk space.

[1] http://koji.fedoraproject.org/koji/taskinfo?taskID=8735163