### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ rvm:
 - 2.1.0
 - 2.2.0
 - ruby-head
+- rbx-2
 script: rake travis
 matrix:
   allow_failures:
     - rvm: 1.8.7
+    - rvm: rbx-2


### PR DESCRIPTION
I would like to add Rubinius to the Travis build to test that rdoc works on Rubinius.