### PR TITLE
Fix for drive letters

### DIFF
--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -353,7 +353,11 @@ option)
     return unless content
 
     filename_path = Pathname(filename).expand_path
-    relative_path = filename_path.relative_path_from @options.root
+    begin
+      relative_path = filename_path.relative_path_from @options.root
+    rescue ArgumentError
+      relative_path = filename_path
+    end
 
     if @options.page_dir and
        relative_path.to_s.start_with? @options.page_dir.to_s then


### PR DESCRIPTION
`Pathname#relative_path_from` raises an `ArgumentError` when the
self path and the base directory have different prefixes, on
Windows and DOSish systems which have drive letters (or UNC).
The absolute path just works fine in that case.