### PR TITLE
minor modification to the data can be generated from other scopes

### DIFF
--- a/lib/rdoc/task.rb
+++ b/lib/rdoc/task.rb
@@ -240,13 +240,13 @@ class RDoc::Task < Rake::TaskLib
     ].flatten.compact
 
     task rdoc_task_name => [rdoc_target]
+    args = option_list + @rdoc_files
     file rdoc_target => rdoc_target_deps do
       @before_running_rdoc.call if @before_running_rdoc
-      args = option_list + @rdoc_files
 
       $stderr.puts "rdoc #{args.join ' '}" if Rake.application.options.trace
-      RDoc::RDoc.new.document args
     end
+    RDoc::RDoc.new.document args
 
     self
   end


### PR DESCRIPTION
Without this modification as "monkey patching" you can not generate, through a "generator" of a "gem" personnel, "rdoc" in the app that install this "gem".