### PR TITLE
Apply those patch to ~> 3.12

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,10 @@
+=== 3.12.3 / 2016-01-29
+
+* Bug fixes
+   * Apply some patch to ~> 3.12
+   * 23c276
+   * 5cfb39
+
 === 3.12.2 / 2013-02-24
 
 * Bug fixes

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -108,7 +108,7 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '3.12.2'
+  VERSION = '3.12.3'
 
   ##
   # Method visibilities

--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -144,6 +144,7 @@ class RDoc::Context < RDoc::CodeObject
   # Contexts are sorted by full_name
 
   def <=>(other)
+    return nil unless RDoc::CodeObject === other
     full_name <=> other.full_name
   end
 

--- a/lib/rdoc/method_attr.rb
+++ b/lib/rdoc/method_attr.rb
@@ -98,7 +98,10 @@ class RDoc::MethodAttr < RDoc::CodeObject
   # Order by #singleton then #name
 
   def <=>(other)
-    [@singleton ? 0 : 1, name] <=> [other.singleton ? 0 : 1, other.name]
+    return unless other.respond_to?(:singleton) &&
+                  other.respond_to?(:name)
+    [     @singleton ? 0 : 1,       name] <=>
+    [other.singleton ? 0 : 1, other.name]
   end
 
   ##


### PR DESCRIPTION
Apply those patch to ~> 3.12
23c276
5cfb39

Because `RubyInstaller` use rdoc(~>3.12) generate html files, this version missing some bug fixes.