### PR TITLE
Include lib/rdoc/generator/pot/* in built gem

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -38,6 +38,9 @@ lib/rdoc/generator/json_index.rb
 lib/rdoc/generator/markup.rb
 lib/rdoc/generator/ri.rb
 lib/rdoc/generator/pot.rb
+lib/rdoc/generator/pot/message_extractor.rb
+lib/rdoc/generator/pot/po.rb
+lib/rdoc/generator/pot/po_entry.rb
 lib/rdoc/generator/template/darkfish/.document
 lib/rdoc/generator/template/darkfish/_footer.rhtml
 lib/rdoc/generator/template/darkfish/_head.rhtml


### PR DESCRIPTION
This fixes #391, the fact that the lib/rdoc/generator/pot/* files are missing in the published 4.2.1 gem.

#### Testing done

Before:
```
$ git checkout master && rm -r pkg \
   && rake package \
   && find pkg/rdoc-4.2.1 -path '*pot*' \! -path '*/test/*'
...
pkg/rdoc-4.2.1/lib/rdoc/generator/pot.rb
```

After:
```
$ git checkout missing_pot && rm -r pkg \
   && rake package \
   && find pkg/rdoc-4.2.1 -path '*pot*' \! -path '*/test/*'
...
pkg/rdoc-4.2.1/lib/rdoc/generator/pot.rb
pkg/rdoc-4.2.1/lib/rdoc/generator/pot
pkg/rdoc-4.2.1/lib/rdoc/generator/pot/message_extractor.rb
pkg/rdoc-4.2.1/lib/rdoc/generator/pot/po_entry.rb
pkg/rdoc-4.2.1/lib/rdoc/generator/pot/po.rb
```