### PR TITLE
Create 4.2.2 release to fix missing files

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,9 @@
+=== 4.2.2 / 2016-02-09
+
+* Bug fixes
+  * Include lib/rdoc/generator/pot/* in built gem
+
+
 === 4.2.1 / 2015-12-22
 
 * Bug fixes

--- a/lib/rdoc.rb
+++ b/lib/rdoc.rb
@@ -64,7 +64,7 @@ module RDoc
   ##
   # RDoc version you are using
 
-  VERSION = '4.2.1'
+  VERSION = '4.2.2'
 
   ##
   # Method visibilities


### PR DESCRIPTION
I'd like to request that a 4.2.2 release be shipped because the 4.2.1 release was missing files -- see #391.

I've created two commits mimicking the ones made for the 4.2.1 release.  I'm pretty sure the lib/rdoc.rb VERSION change is straightfoward.  If I've misunderstood the change to the History file (i.e. it's generated, or the date will be wrong) please feel free to ignore or fix that commit.

#### Testing Done

```
$ rm -r pkg && rake package && find pkg/rdoc-4.2.2 -path '*pot*' \! -path '*/test/*'
...
pkg/rdoc-4.2.2/lib/rdoc/generator/pot.rb
pkg/rdoc-4.2.2/lib/rdoc/generator/pot
pkg/rdoc-4.2.2/lib/rdoc/generator/pot/message_extractor.rb
pkg/rdoc-4.2.2/lib/rdoc/generator/pot/po_entry.rb
pkg/rdoc-4.2.2/lib/rdoc/generator/pot/po.rb
```
```
$ rake test
...
Finished tests in 10.140773s, 211.8182 tests/s, 504.3008 assertions/s.

2148 tests, 5114 assertions, 0 failures, 0 errors, 1 skips
...
Finished benchmarks in 0.226885s, 4.4075 tests/s, 4.4075 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 1 skips
```