### PR TITLE
Remove hoe from development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /lib/rdoc/markdown.rb
 /pkg
 /tmp
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 ---
-after_script:
-- rake travis:after -t
 before_script:
-- gem install hoe-travis --no-rdoc --no-ri
-- rake travis:before -t
+- gem install bundler --no-document
 language: ruby
 notifications:
   email:
@@ -16,7 +13,7 @@ rvm:
 - 2.2.0
 - ruby-head
 - rbx-2
-script: rake travis
+script: rake
 matrix:
   allow_failures:
     - rvm: 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 ---
-before_script:
-- gem install bundler --no-document
+before_install:
+  - gem install bundler --no-document
 language: ruby
 notifications:
   email:
   - mail@zzak.io
 rvm:
-- 1.8.7
-- 1.9.3
-- 2.0.0
-- 2.1.0
-- 2.2.0
-- ruby-head
-- rbx-2
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - ruby-head
+  - rbx-2
 script: rake
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,7 @@
 home :: https://github.com/rdoc/rdoc
 rdoc :: http://docs.seattlerb.org/rdoc
 bugs :: https://github.com/rdoc/rdoc/issues
+build status :: {<img src="https://travis-ci.org/rdoc/rdoc.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/rdoc/rdoc]
 code quality :: {<img src="https://codeclimate.com/badge.png" alt="code climate">}[https://codeclimate.com/github/rdoc/rdoc]
 
 == Description

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
-require_relative 'lib/rdoc'
+$:.push File.expand_path("../lib", __FILE__)
+require 'rdoc'
 
 Gem::Specification.new do |s|
   s.name = "rdoc"

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+require_relative 'lib/rdoc'
+
+Gem::Specification.new do |s|
+  s.name = "rdoc"
+  s.version = RDoc::VERSION
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 1.3") if
+    s.respond_to? :required_rubygems_version=
+
+  s.require_paths = ["lib"]
+  s.authors = [
+    "Eric Hodel",
+    "Dave Thomas",
+    "Phil Hagelberg",
+    "Tony Strauss",
+    "Zachary Scott"
+  ]
+
+  s.description = <<-DESCRIPTION
+RDoc produces HTML and command-line documentation for Ruby projects.
+RDoc includes the +rdoc+ and +ri+ tools for generating and displaying documentation from the command-line.
+  DESCRIPTION
+
+  s.email = ["drbrain@segment7.net", "mail@zzak.io"]
+
+  s.executables = ["rdoc", "ri"]
+
+  s.extra_rdoc_files += %w[
+    CVE-2013-0256.rdoc
+    CONTRIBUTING.rdoc
+    ExampleMarkdown.md
+    ExampleRDoc.rdoc
+    History.rdoc
+    LEGAL.rdoc
+    LICENSE.rdoc
+    README.rdoc
+    RI.rdoc
+    TODO.rdoc
+  ]
+
+  s.files = File.readlines("Manifest.txt").map { |l| l.gsub("\n",'') }
+
+  s.homepage = "http://docs.seattlerb.org/rdoc"
+  s.licenses = ["Ruby"]
+  s.post_install_message = <<-MESSAGE
+Depending on your version of ruby, you may need to install ruby rdoc/ri data:
+
+<= 1.8.6 : unsupported
+ = 1.8.7 : gem install rdoc-data; rdoc-data --install
+ = 1.9.1 : gem install rdoc-data; rdoc-data --install
+>= 1.9.2 : nothing to do! Yay!
+  MESSAGE
+
+  s.rdoc_options = ["--main", "README.rdoc"]
+  s.required_ruby_version = Gem::Requirement.new(">= 1.8.7")
+  s.rubygems_version = "2.5.2"
+  s.summary = "RDoc produces HTML and command-line documentation for Ruby projects"
+
+  s.add_runtime_dependency("json", "~> 1.4")
+  s.add_development_dependency("racc", "~> 1.4", "> 1.4.10")
+  s.add_development_dependency("kpeg", "~> 0.9")
+  s.add_development_dependency("minitest", "~> 4")
+end

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -58,6 +58,7 @@ Depending on your version of ruby, you may need to install ruby rdoc/ri data:
   s.summary = "RDoc produces HTML and command-line documentation for Ruby projects"
 
   s.add_runtime_dependency("json", "~> 1.4")
+  s.add_development_dependency("rake", "~> 10.5")
   s.add_development_dependency("racc", "~> 1.4", "> 1.4.10")
   s.add_development_dependency("kpeg", "~> 0.9")
   s.add_development_dependency("minitest", "~> 4")


### PR DESCRIPTION
I want to remove hoe to make it easier for testing plugins and third-party extensions against master.

Removing hoe will simplify the Rakefile and reduced the number of dependencies we have to maintain.

This also allows testing extensions and plugins easier, but also contributors will have a much more familiar workflow to contribute; which IMO is the biggest benefit and worth the complexity of moving parser generation onto our Rakefile.