### PR TITLE
Improve expand class name

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -907,22 +907,9 @@ The ri pager can be set with the 'RI_PAGER' environment variable or the
   # will be expanded to Zlib::DataError.
 
   def expand_class klass
-    klass.split('::').inject '' do |expanded, klass_part|
-      expanded << '::' unless expanded.empty?
-      short = expanded << klass_part
-
-      subset = classes.keys.select do |klass_name|
-        klass_name =~ /^#{expanded}[^:]*$/
-      end
-
-      abbrevs = Abbrev.abbrev subset
-
-      expanded = abbrevs[short]
-
-      raise NotFoundError, short unless expanded
-
-      expanded.dup
-    end
+    ary = classes.keys.grep(Regexp.new("\\A#{klass.gsub(/(?=::|\z)/, '[^:]*')}\\z"))
+    raise NotFoundError, klass if ary.length != 1
+    ary.first
   end
 
   ##

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -834,6 +834,24 @@ Foo::Bar#bother
     end
   end
 
+  def test_expand_class_2
+    @store1 = RDoc::RI::Store.new @home_ri, :home
+
+    @top_level = @store1.add_file 'file.rb'
+
+    @cFoo = @top_level.add_class RDoc::NormalClass, 'Foo'
+    @mFox = @top_level.add_module RDoc::NormalModule, 'Fox'
+    @cFoo_Bar = @cFoo.add_class RDoc::NormalClass, 'Bar'
+    @store1.save
+
+    @driver.stores = [@store1]
+    assert_raises RDoc::RI::Driver::NotFoundError do
+      @driver.expand_class 'F'
+    end
+    assert_equal 'Foo::Bar',  @driver.expand_class('F::Bar')
+    assert_equal 'Foo::Bar',  @driver.expand_class('F::B')
+  end
+
   def test_expand_name
     util_store
 


### PR DESCRIPTION
Make it return the class name when it can identify the class with given
child name even if it cannot identify ancestors, return the class name.