### PR TITLE
Ignore frozen_string_literal magic comment (Fixes #389)

### DIFF
--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -74,10 +74,21 @@ module RDoc::Encoding
     nil
   end
 
+  def self.remove_frozen_string_literal string
+    string =~ /\A(?:#!.*\n)?(.*\n)/
+    first_line = $1
+
+    if first_line =~ /\A# +frozen[-_]string[-_]literal[=:].+$/i
+      string.sub! first_line, ''
+    end
+  end
+
   ##
   # Sets the encoding of +string+ based on the magic comment
 
   def self.set_encoding string
+    remove_frozen_string_literal string
+
     string =~ /\A(?:#!.*\n)?(.*\n)/
 
     first_line = $1
@@ -89,6 +100,8 @@ module RDoc::Encoding
            end
 
     string.sub! first_line, ''
+
+    remove_frozen_string_literal string
 
     return unless Object.const_defined? :Encoding
 

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -217,6 +217,45 @@ class TestRDocEncoding < RDoc::TestCase
     end
   end
 
+  def test_skip_frozen_string_literal
+    skip "Encoding not implemented" unless Object.const_defined? :Encoding
+
+    expected = "# frozen_string_literal: false\nhi everybody"
+
+    @tempfile.write expected
+    @tempfile.flush
+
+    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
+    assert_equal "hi everybody", contents
+    assert_equal Encoding::UTF_8, contents.encoding
+  end
+
+  def test_skip_frozen_string_literal_after_coding
+    skip "Encoding not implemented" unless Object.const_defined? :Encoding
+
+    expected = "# coding: utf-8\n# frozen-string-literal: false\nhi everybody"
+
+    @tempfile.write expected
+    @tempfile.flush
+
+    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
+    assert_equal "hi everybody", contents
+    assert_equal Encoding::UTF_8, contents.encoding
+  end
+
+  def test_skip_frozen_string_literal_before_coding
+    skip "Encoding not implemented" unless Object.const_defined? :Encoding
+
+    expected = "# frozen_string_literal: false\n# coding: utf-8\nhi everybody"
+
+    @tempfile.write expected
+    @tempfile.flush
+
+    contents = RDoc::Encoding.read_file @tempfile.path, Encoding::UTF_8
+    assert_equal "hi everybody", contents
+    assert_equal Encoding::UTF_8, contents.encoding
+  end
+
   def test_sanity
     skip "Encoding not implemented" unless Object.const_defined? :Encoding
 


### PR DESCRIPTION
I believe that ruby supports magic comments in any order. Note
that ruby appears to support a warn_indent magic comment which
this doesn't handle.