### PR TITLE
Removed strict dependency for json, it break to install ruby trunk(2.4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
   email:
   - mail@zzak.io
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.10

--- a/rdoc.gemspec
+++ b/rdoc.gemspec
@@ -54,11 +54,10 @@ Depending on your version of ruby, you may need to install ruby rdoc/ri data:
   MESSAGE
 
   s.rdoc_options = ["--main", "README.rdoc"]
-  s.required_ruby_version = Gem::Requirement.new(">= 1.8.7")
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
   s.rubygems_version = "2.5.2"
   s.summary = "RDoc produces HTML and command-line documentation for Ruby projects"
 
-  s.add_runtime_dependency("json", "~> 1.4")
   s.add_development_dependency("rake", "~> 10.5")
   s.add_development_dependency("racc", "~> 1.4", "> 1.4.10")
   s.add_development_dependency("kpeg", "~> 0.9")


### PR DESCRIPTION
Ruby 2.4 can not build json-1.8.3. because it uses `rb_cFixnum`. this pull request allows to install json 2.0 later with rdoc.