### PR TITLE
fix NotFoundError with left-hand match class like String and StringIO

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -908,7 +908,7 @@ The ri pager can be set with the 'RI_PAGER' environment variable or the
 
   def expand_class klass
     ary = classes.keys.grep(Regexp.new("\\A#{klass.gsub(/(?=::|\z)/, '[^:]*')}\\z"))
-    raise NotFoundError, klass if ary.length != 1
+    raise NotFoundError, klass if ary.length != 1 && ary.first != klass
     ary.first
   end
 
@@ -1480,4 +1480,3 @@ The ri pager can be set with the 'RI_PAGER' environment variable or the
   end
 
 end
-

--- a/test/test_rdoc_ri_driver.rb
+++ b/test/test_rdoc_ri_driver.rb
@@ -852,6 +852,20 @@ Foo::Bar#bother
     assert_equal 'Foo::Bar',  @driver.expand_class('F::B')
   end
 
+  def test_expand_class_3
+    @store1 = RDoc::RI::Store.new @home_ri, :home
+
+    @top_level = @store1.add_file 'file.rb'
+
+    @cFoo = @top_level.add_class RDoc::NormalClass, 'Foo'
+    @mFox = @top_level.add_module RDoc::NormalModule, 'FooBar'
+    @store1.save
+
+    @driver.stores = [@store1]
+
+    assert_equal 'Foo',  @driver.expand_class('Foo')
+  end
+
   def test_expand_name
     util_store
 
@@ -1452,4 +1466,3 @@ Foo::Bar#bother
   end
 
 end
-


### PR DESCRIPTION
see details (in Japanese): https://twitter.com/k_tsj/status/773428042073079809

If given classes like String, StringIO, StringScanner, ri could not find `String` class.