### PR TITLE
Removed code for Ruby 1.8 

### DIFF
--- a/lib/rdoc/code_object.rb
+++ b/lib/rdoc/code_object.rb
@@ -150,8 +150,7 @@ class RDoc::CodeObject
                  else
                    # HACK correct fix is to have #initialize create @comment
                    #      with the correct encoding
-                   if String === @comment and
-                      Object.const_defined? :Encoding and @comment.empty? then
+                   if String === @comment and @comment.empty? then
                      @comment.force_encoding comment.encoding
                    end
                    @comment
@@ -427,4 +426,3 @@ class RDoc::CodeObject
   end
 
 end
-

--- a/lib/rdoc/comment.rb
+++ b/lib/rdoc/comment.rb
@@ -200,7 +200,7 @@ class RDoc::Comment
   def remove_private
     # Workaround for gsub encoding for Ruby 1.9.2 and earlier
     empty = ''
-    empty.force_encoding @text.encoding if Object.const_defined? :Encoding
+    empty.force_encoding @text.encoding
 
     @text = @text.gsub(%r%^\s*([#*]?)--.*?^\s*(\1)\+\+\n?%m, empty)
     @text = @text.sub(%r%^\s*[#*]?--.*%m, '')
@@ -227,4 +227,3 @@ class RDoc::Comment
   end
 
 end
-

--- a/lib/rdoc/encoding.rb
+++ b/lib/rdoc/encoding.rb
@@ -25,43 +25,41 @@ module RDoc::Encoding
 
     RDoc::Encoding.set_encoding content
 
-    if Object.const_defined? :Encoding then
-      begin
-        encoding ||= Encoding.default_external
-        orig_encoding = content.encoding
+    begin
+      encoding ||= Encoding.default_external
+      orig_encoding = content.encoding
 
-        if not orig_encoding.ascii_compatible? then
-          content.encode! encoding
-        elsif utf8 then
-          content.force_encoding Encoding::UTF_8
-          content.encode! encoding
-        else
-          # assume the content is in our output encoding
-          content.force_encoding encoding
-        end
+      if not orig_encoding.ascii_compatible? then
+        content.encode! encoding
+      elsif utf8 then
+        content.force_encoding Encoding::UTF_8
+        content.encode! encoding
+      else
+        # assume the content is in our output encoding
+        content.force_encoding encoding
+      end
 
-        unless content.valid_encoding? then
-          # revert and try to transcode
-          content.force_encoding orig_encoding
-          content.encode! encoding
-        end
+      unless content.valid_encoding? then
+        # revert and try to transcode
+        content.force_encoding orig_encoding
+        content.encode! encoding
+      end
 
-        unless content.valid_encoding? then
-          warn "unable to convert #{filename} to #{encoding}, skipping"
-          content = nil
-        end
-      rescue Encoding::InvalidByteSequenceError,
-             Encoding::UndefinedConversionError => e
-        if force_transcode then
-          content.force_encoding orig_encoding
-          content.encode!(encoding,
-                          :invalid => :replace, :undef => :replace,
-                          :replace => '?')
-          return content
-        else
-          warn "unable to convert #{e.message} for #{filename}, skipping"
-          return nil
-        end
+      unless content.valid_encoding? then
+        warn "unable to convert #{filename} to #{encoding}, skipping"
+        content = nil
+      end
+    rescue Encoding::InvalidByteSequenceError,
+           Encoding::UndefinedConversionError => e
+      if force_transcode then
+        content.force_encoding orig_encoding
+        content.encode!(encoding,
+                        :invalid => :replace, :undef => :replace,
+                        :replace => '?')
+        return content
+      else
+        warn "unable to convert #{e.message} for #{filename}, skipping"
+        return nil
       end
     end
 
@@ -103,11 +101,8 @@ module RDoc::Encoding
 
     remove_frozen_string_literal string
 
-    return unless Object.const_defined? :Encoding
-
     enc = Encoding.find name
     string.force_encoding enc if enc
   end
 
 end
-

--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -698,7 +698,7 @@ class RDoc::Generator::Darkfish
 
       out_file.dirname.mkpath
       out_file.open 'w', 0644 do |io|
-        io.set_encoding @options.encoding if Object.const_defined? :Encoding
+        io.set_encoding @options.encoding
 
         @context = yield io
 
@@ -744,8 +744,7 @@ class RDoc::Generator::Darkfish
       erbout = 'io'
     else
       template = file.read
-      template = template.encode @options.encoding if
-        Object.const_defined? :Encoding
+      template = template.encode @options.encoding
 
       file_var = File.basename(file).sub(/\..*/, '')
 
@@ -758,4 +757,3 @@ class RDoc::Generator::Darkfish
   end
 
 end
-

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -142,7 +142,7 @@ class RDoc::Generator::JsonIndex
     FileUtils.mkdir_p index_file.dirname, :verbose => $DEBUG_RDOC
 
     index_file.open 'w', 0644 do |io|
-      io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
+      io.set_encoding Encoding::UTF_8
       io.write 'var search_data = '
 
       JSON.dump data, io, 0
@@ -295,4 +295,3 @@ class RDoc::Generator::JsonIndex
   end
 
 end
-

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -79,7 +79,6 @@ class RDoc::Markup::Parser
     @binary_input   = nil
     @current_token  = nil
     @debug          = false
-    @have_encoding  = Object.const_defined? :Encoding
     @input          = nil
     @input_encoding = nil
     @line           = 0

--- a/lib/rdoc/markup/parser.rb
+++ b/lib/rdoc/markup/parser.rb
@@ -80,7 +80,6 @@ class RDoc::Markup::Parser
     @current_token  = nil
     @debug          = false
     @have_encoding  = Object.const_defined? :Encoding
-    @have_byteslice = ''.respond_to? :byteslice
     @input          = nil
     @input_encoding = nil
     @line           = 0
@@ -324,15 +323,7 @@ class RDoc::Markup::Parser
   # The character offset for the input string at the given +byte_offset+
 
   def char_pos byte_offset
-    if @have_byteslice then
-      @input.byteslice(0, byte_offset).length
-    elsif @have_encoding then
-      matched = @binary_input[0, byte_offset]
-      matched.force_encoding @input_encoding
-      matched.length
-    else
-      byte_offset
-    end
+    @input.byteslice(0, byte_offset).length
   end
 
   ##
@@ -429,11 +420,6 @@ class RDoc::Markup::Parser
     @line     = 0
     @line_pos = 0
     @input    = input.dup
-
-    if @have_encoding and not @have_byteslice then
-      @input_encoding = @input.encoding
-      @binary_input   = @input.force_encoding Encoding::BINARY
-    end
 
     @s = StringScanner.new input
   end
@@ -556,4 +542,3 @@ class RDoc::Markup::Parser
   end
 
 end
-

--- a/lib/rdoc/options.rb
+++ b/lib/rdoc/options.rb
@@ -379,23 +379,15 @@ class RDoc::Options
     @visibility = :protected
     @webcvs = nil
     @write_options = false
-
-    if Object.const_defined? :Encoding then
-      @encoding = Encoding::UTF_8
-      @charset = @encoding.name
-    else
-      @encoding = nil
-      @charset = 'UTF-8'
-    end
+    @encoding = Encoding::UTF_8
+    @charset = @encoding.name
   end
 
   def init_with map # :nodoc:
     init_ivars
 
     encoding = map['encoding']
-    @encoding = if Object.const_defined? :Encoding then
-                  encoding ? Encoding.find(encoding) : encoding
-                end
+    @encoding = encoding ? Encoding.find(encoding) : encoding
 
     @charset        = map['charset']
     @exclude        = map['exclude']
@@ -689,19 +681,16 @@ Usage: #{opt.program_name} [options] [names...]
       opt.separator "Parsing options:"
       opt.separator nil
 
-      if Object.const_defined? :Encoding then
-        opt.on("--encoding=ENCODING", "-e", Encoding.list.map { |e| e.name },
-               "Specifies the output encoding.  All files",
-               "read will be converted to this encoding.",
-               "The default encoding is UTF-8.",
-               "--encoding is preferred over --charset") do |value|
-                 @encoding = Encoding.find value
-                 @charset = @encoding.name # may not be valid value
-               end
+      opt.on("--encoding=ENCODING", "-e", Encoding.list.map { |e| e.name },
+             "Specifies the output encoding.  All files",
+             "read will be converted to this encoding.",
+             "The default encoding is UTF-8.",
+             "--encoding is preferred over --charset") do |value|
+               @encoding = Encoding.find value
+               @charset = @encoding.name # may not be valid value
+             end
 
-        opt.separator nil
-      end
-
+      opt.separator nil
 
       opt.on("--locale=NAME",
              "Specifies the output locale.") do |value|
@@ -1242,11 +1231,10 @@ Usage: #{opt.program_name} [options] [names...]
     RDoc.load_yaml
 
     open '.rdoc_options', 'w' do |io|
-      io.set_encoding Encoding::UTF_8 if Object.const_defined? :Encoding
+      io.set_encoding Encoding::UTF_8
 
       YAML.dump self, io
     end
   end
 
 end
-

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -170,9 +170,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
     @prev_seek = nil
     @markup = @options.markup
     @track_visibility = :nodoc != @options.visibility
-
-    @encoding = nil
-    @encoding = @options.encoding if Object.const_defined? :Encoding
+    @encoding = @options.encoding
 
     reset
   end
@@ -2158,4 +2156,3 @@ class RDoc::Parser::Ruby < RDoc::Parser
   end
 
 end
-

--- a/lib/rdoc/parser/simple.rb
+++ b/lib/rdoc/parser/simple.rb
@@ -52,11 +52,10 @@ class RDoc::Parser::Simple < RDoc::Parser
   def remove_private_comment comment
     # Workaround for gsub encoding for Ruby 1.9.2 and earlier
     empty = ''
-    empty.force_encoding comment.encoding if Object.const_defined? :Encoding
+    empty.force_encoding comment.encoding
 
     comment = comment.gsub(%r%^--\n.*?^\+\+\n?%m, empty)
     comment.sub(%r%^--\n.*%m, empty)
   end
 
 end
-

--- a/lib/rdoc/rdoc.rb
+++ b/lib/rdoc/rdoc.rb
@@ -340,10 +340,8 @@ option)
   # Parses +filename+ and returns an RDoc::TopLevel
 
   def parse_file filename
-    if Object.const_defined? :Encoding then
-      encoding = @options.encoding
-      filename = filename.encode encoding
-    end
+    encoding = @options.encoding
+    filename = filename.encode encoding
 
     @stats.add_file filename
 

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -39,8 +39,6 @@ class RDoc::TestCase < MiniTest::Unit::TestCase
 
     @top_level = nil
 
-    @have_encoding = Object.const_defined? :Encoding
-
     @RM = RDoc::Markup
 
     RDoc::Markup::PreProcess.reset

--- a/lib/rdoc/text.rb
+++ b/lib/rdoc/text.rb
@@ -52,7 +52,7 @@ module RDoc::Text
       :open_squote  => encode_fallback('‘', encoding, '\''),
       :trademark    => encode_fallback('®', encoding, '(r)'),
     }
-  end if Object.const_defined? :Encoding
+  end
 
   ##
   # Transcodes +character+ to +encoding+ with a +fallback+ character.
@@ -71,7 +71,7 @@ module RDoc::Text
     text.each_line do |line|
       nil while line.gsub!(/(?:\G|\r)((?:.{8})*?)([^\t\r\n]{0,7})\t/) do
         r = "#{$1}#{$2}#{' ' * (8 - $2.size)}"
-        r.force_encoding text.encoding if Object.const_defined? :Encoding
+        r.force_encoding text.encoding
         r
       end
 
@@ -93,7 +93,7 @@ module RDoc::Text
     end
 
     empty = ''
-    empty.force_encoding text.encoding if Object.const_defined? :Encoding
+    empty.force_encoding text.encoding
 
     text.gsub(/^ {0,#{indent}}/, empty)
   end
@@ -160,7 +160,7 @@ module RDoc::Text
     return text if text =~ /^(?>\s*)[^\#]/
 
     empty = ''
-    empty.force_encoding text.encoding if Object.const_defined? :Encoding
+    empty.force_encoding text.encoding
 
     text.gsub(/^\s*(#+)/) { $1.tr '#', ' ' }.gsub(/^\s+$/, empty)
   end
@@ -178,7 +178,7 @@ module RDoc::Text
   def strip_stars text
     return text unless text =~ %r%/\*.*\*/%m
 
-    encoding = text.encoding if Object.const_defined? :Encoding
+    encoding = text.encoding
 
     text = text.gsub %r%Document-method:\s+[\w:.#=!?]+%, ''
 
@@ -199,24 +199,9 @@ module RDoc::Text
   # trademark symbols in +text+ to properly encoded characters.
 
   def to_html text
-    if Object.const_defined? :Encoding then
-      html = ''.encode text.encoding
+    html = ''.encode text.encoding
 
-      encoded = RDoc::Text::TO_HTML_CHARACTERS[text.encoding]
-    else
-      html = ''
-      encoded = {
-        :close_dquote => '”',
-        :close_squote => '’',
-        :copyright    => '©',
-        :ellipsis     => '…',
-        :em_dash      => '—',
-        :en_dash      => '–',
-        :open_dquote  => '“',
-        :open_squote  => '‘',
-        :trademark    => '®',
-      }
-    end
+    encoded = RDoc::Text::TO_HTML_CHARACTERS[text.encoding]
 
     s = StringScanner.new text
     insquotes = false

--- a/test/test_rdoc_code_object.rb
+++ b/test/test_rdoc_code_object.rb
@@ -50,8 +50,6 @@ class TestRDocCodeObject < XrefTestCase
   end
 
   def test_comment_equals_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     refute_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     input = 'text'
@@ -64,8 +62,6 @@ class TestRDocCodeObject < XrefTestCase
   end
 
   def test_comment_equals_encoding_blank
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     refute_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     input = ''
@@ -448,4 +444,3 @@ class TestRDocCodeObject < XrefTestCase
   end
 
 end
-

--- a/test/test_rdoc_comment.rb
+++ b/test/test_rdoc_comment.rb
@@ -207,8 +207,6 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
   def test_force_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @comment.force_encoding Encoding::UTF_8
 
     assert_equal Encoding::UTF_8, @comment.text.encoding
@@ -343,8 +341,6 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
   def test_remove_private_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     comment = RDoc::Comment.new <<-EOS, @top_level
 # This is text
 #--
@@ -467,8 +463,6 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
   def test_remove_private_toggle_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     comment = RDoc::Comment.new <<-EOS, @top_level
 # This is text
 #--
@@ -485,8 +479,6 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
   def test_remove_private_toggle_encoding_ruby_bug?
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     comment = RDoc::Comment.new <<-EOS, @top_level
 #--
 # this is private
@@ -502,4 +494,3 @@ lines, one line per element. Lines are assumed to be separated by _sep_.
   end
 
 end
-

--- a/test/test_rdoc_encoding.rb
+++ b/test/test_rdoc_encoding.rb
@@ -25,8 +25,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     expected = "# coding: utf-8\nhi everybody"
 
     @tempfile.write expected
@@ -38,8 +36,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_convert
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     content = ""
     content.encode! 'ISO-8859-1'
     content << "# coding: ISO-8859-1\nhi \xE9verybody"
@@ -53,8 +49,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_fail
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @tempfile.write "# coding: utf-8\n\317\200" # pi
     @tempfile.flush
 
@@ -70,8 +64,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_fancy
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     expected = "# -*- coding: utf-8; fill-column: 74 -*-\nhi everybody"
     expected.encode! Encoding::UTF_8
 
@@ -84,8 +76,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_force_transcode
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @tempfile.write "# coding: utf-8\n\317\200" # pi
     @tempfile.flush
 
@@ -96,8 +86,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_guess
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     path = File.expand_path '../test.ja.txt', __FILE__
     content = RDoc::Encoding.read_file path, Encoding::UTF_8
 
@@ -105,8 +93,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_invalid
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @tempfile.write "# coding: ascii\nM\xE4r"
     @tempfile.flush
 
@@ -121,8 +107,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_with_signature
-    skip "Encoding not implemented" unless defined? ::Encoding
-
     @tempfile.write "\xEF\xBB\xBFhi everybody"
     @tempfile.flush
 
@@ -133,8 +117,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_read_file_encoding_iso_2022_jp
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     input = "# coding: ISO-2022-JP\n:\e$B%3%^%s%I\e(B:"
 
     @tempfile.write input
@@ -154,8 +136,6 @@ class TestRDocEncoding < RDoc::TestCase
     RDoc::Encoding.set_encoding s
 
     # sanity check for 1.8
-
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
 
     assert_equal Encoding::UTF_8, s.encoding
 
@@ -192,8 +172,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_class_set_encoding_bad
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     s = ""
     expected = s.encoding
     RDoc::Encoding.set_encoding s
@@ -218,8 +196,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_skip_frozen_string_literal
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     expected = "# frozen_string_literal: false\nhi everybody"
 
     @tempfile.write expected
@@ -231,8 +207,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_skip_frozen_string_literal_after_coding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     expected = "# coding: utf-8\n# frozen-string-literal: false\nhi everybody"
 
     @tempfile.write expected
@@ -244,8 +218,6 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_skip_frozen_string_literal_before_coding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     expected = "# frozen_string_literal: false\n# coding: utf-8\nhi everybody"
 
     @tempfile.write expected
@@ -257,11 +229,8 @@ class TestRDocEncoding < RDoc::TestCase
   end
 
   def test_sanity
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     assert_equal Encoding::US_ASCII, ''.encoding,
                  'If this file is not ASCII tests may incorrectly pass'
   end
 
 end
-

--- a/test/test_rdoc_generator_darkfish.rb
+++ b/test/test_rdoc_generator_darkfish.rb
@@ -83,11 +83,7 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
     assert_hard_link 'fonts/SourceCodePro-Bold.ttf'
     assert_hard_link 'fonts/SourceCodePro-Regular.ttf'
 
-    encoding = if Object.const_defined? :Encoding then
-                 Regexp.escape Encoding::UTF_8.name
-               else
-                 Regexp.escape 'UTF-8'
-               end
+    encoding = Regexp.escape Encoding::UTF_8.name
 
     assert_match %r%<meta charset="#{encoding}">%, File.read('index.html')
     assert_match %r%<meta charset="#{encoding}">%, File.read('Object.html')
@@ -227,4 +223,3 @@ class TestRDocGeneratorDarkfish < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_generator_json_index.rb
+++ b/test/test_rdoc_generator_json_index.rb
@@ -198,8 +198,6 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
   end
 
   def test_generate_utf_8
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     text = "5\xB0"
     text.force_encoding Encoding::ISO_8859_1
     @klass.add_comment comment(text), @top_level
@@ -322,4 +320,3 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_generator_ri.rb
+++ b/test/test_rdoc_generator_ri.rb
@@ -7,10 +7,8 @@ class TestRDocGeneratorRI < RDoc::TestCase
     super
 
     @options = RDoc::Options.new
-    if Object.const_defined? :Encoding then
-      @options.encoding = Encoding::UTF_8
-      @store.encoding = Encoding::UTF_8
-    end
+    @options.encoding = Encoding::UTF_8
+    @store.encoding = Encoding::UTF_8
 
     @tmpdir = File.join Dir.tmpdir, "test_rdoc_generator_ri_#{$$}"
     FileUtils.mkdir_p @tmpdir
@@ -57,7 +55,7 @@ class TestRDocGeneratorRI < RDoc::TestCase
     store = RDoc::RI::Store.new @tmpdir
     store.load_cache
 
-    encoding = Object.const_defined?(:Encoding) ? Encoding::UTF_8 : nil
+    encoding = Encoding::UTF_8
 
     assert_equal encoding, store.encoding
   end
@@ -76,4 +74,3 @@ class TestRDocGeneratorRI < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_markup_parser.rb
+++ b/test/test_rdoc_markup_parser.rb
@@ -28,11 +28,7 @@ class TestRDocMarkupParser < RDoc::TestCase
 
     s.scan(/\S+/)
 
-    if @have_encoding then
-      assert_equal 3, parser.char_pos(s.pos)
-    else
-      assert_equal 4, parser.char_pos(s.pos)
-    end
+    assert_equal 3, parser.char_pos(s.pos)
   end
 
   def test_get
@@ -1358,8 +1354,6 @@ cat::
   end
 
   def test_tokenize_note_utf_8
-    skip 'Encoding not implemented' unless @have_encoding
-
     str = <<-STR
 cät:: l1a
       l1b
@@ -1624,11 +1618,7 @@ Example heading:
 
     s.scan(/\S+/)
 
-    if @have_encoding then
-      assert_equal [3, 0], parser.token_pos(s.pos)
-    else
-      assert_equal [4, 0], parser.token_pos(s.pos)
-    end
+    assert_equal [3, 0], parser.token_pos(s.pos)
   end
 
   # HACK move to Verbatim test case

--- a/test/test_rdoc_markup_parser.rb
+++ b/test/test_rdoc_markup_parser.rb
@@ -8,8 +8,6 @@ class TestRDocMarkupParser < RDoc::TestCase
   def setup
     super
 
-    @have_byteslice = ''.respond_to? :byteslice
-
     @RMP = @RM::Parser
   end
 
@@ -30,7 +28,7 @@ class TestRDocMarkupParser < RDoc::TestCase
 
     s.scan(/\S+/)
 
-    if @have_byteslice or @have_encoding then
+    if @have_encoding then
       assert_equal 3, parser.char_pos(s.pos)
     else
       assert_equal 4, parser.char_pos(s.pos)
@@ -1626,7 +1624,7 @@ Example heading:
 
     s.scan(/\S+/)
 
-    if @have_encoding or @have_byteslice then
+    if @have_encoding then
       assert_equal [3, 0], parser.token_pos(s.pos)
     else
       assert_equal [4, 0], parser.token_pos(s.pos)
@@ -1678,4 +1676,3 @@ some more text over here
   end
 
 end
-

--- a/test/test_rdoc_markup_pre_process.rb
+++ b/test/test_rdoc_markup_pre_process.rb
@@ -55,8 +55,6 @@ contents of a string.
   end
 
   def test_include_file_encoding_incompatible
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @tempfile.write <<-INCLUDE
 # -*- mode: rdoc; coding: utf-8; fill-column: 74; -*-
 
@@ -471,4 +469,3 @@ contents of a string.
   end
 
 end
-

--- a/test/test_rdoc_options.rb
+++ b/test/test_rdoc_options.rb
@@ -60,7 +60,7 @@ class TestRDocOptions < RDoc::TestCase
 
     @options.encode_with coder
 
-    encoding = Object.const_defined?(:Encoding) ? 'UTF-8' : nil
+    encoding = 'UTF-8'
 
     expected = {
       'charset'              => 'UTF-8',
@@ -122,8 +122,6 @@ class TestRDocOptions < RDoc::TestCase
   end
 
   def test_encoding_default
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     assert_equal Encoding::UTF_8, @options.encoding
   end
 
@@ -142,7 +140,6 @@ class TestRDocOptions < RDoc::TestCase
   end
 
   def test_init_with_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
     RDoc.load_yaml
 
     @options.encoding = Encoding::IBM437
@@ -273,8 +270,6 @@ rdoc_include:
   end
 
   def test_parse_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @options.parse %w[--encoding Big5]
 
     assert_equal Encoding::Big5, @options.encoding
@@ -282,8 +277,6 @@ rdoc_include:
   end
 
   def test_parse_encoding_invalid
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     out, err = capture_io do
       @options.parse %w[--encoding invalid]
     end
@@ -764,4 +757,3 @@ rdoc_include:
     assert_equal :private, @options.visibility
   end
 end
-

--- a/test/test_rdoc_parser.rb
+++ b/test/test_rdoc_parser.rb
@@ -47,8 +47,6 @@ class TestRDocParser < RDoc::TestCase
   end
 
   def test_class_binary_large_japanese_rdoc
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     capture_io do
       begin
         extenc, Encoding.default_external =
@@ -62,8 +60,6 @@ class TestRDocParser < RDoc::TestCase
   end
 
   def test_class_binary_japanese_rdoc
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     file_name = File.expand_path '../test.ja.rdoc', __FILE__
     refute @RP.binary?(file_name)
   end
@@ -325,4 +321,3 @@ class TestRDocParser < RDoc::TestCase
   end
 
 end
-

--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -48,8 +48,6 @@ class C; end
   end
 
   def test_collect_first_comment_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     @options.encoding = Encoding::CP852
 
     p = util_parser <<-CONTENT
@@ -1928,8 +1926,7 @@ end
 
     method = "def ω() end"
 
-    assert_equal Encoding::UTF_8, method.encoding if
-      Object.const_defined? :Encoding
+    assert_equal Encoding::UTF_8, method.encoding
 
     util_parser method
 
@@ -2023,7 +2020,6 @@ end
   end
 
   def test_parse_statements_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
     @options.encoding = Encoding::CP852
 
     content = <<-EOF
@@ -3320,4 +3316,3 @@ end
   end
 
 end
-

--- a/test/test_rdoc_rdoc.rb
+++ b/test/test_rdoc_rdoc.rb
@@ -249,7 +249,6 @@ class TestRDocRDoc < RDoc::TestCase
   end
 
   def test_parse_file_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
     @rdoc.options.encoding = Encoding::ISO_8859_1
     @rdoc.store = RDoc::Store.new
 
@@ -454,4 +453,3 @@ class TestRDocRDoc < RDoc::TestCase
     end
   end
 end
-

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -429,8 +429,6 @@ class TestRDocStore < XrefTestCase
   end
 
   def test_load_cache_encoding_differs
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     cache = {
       :c_class_variables           => {},
       :c_singleton_class_variables => {},
@@ -991,4 +989,3 @@ class TestRDocStore < XrefTestCase
   end
 
 end
-

--- a/test/test_rdoc_text.rb
+++ b/test/test_rdoc_text.rb
@@ -16,8 +16,6 @@ class TestRDocText < RDoc::TestCase
   end
 
   def test_self_encode_fallback
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     assert_equal '…',
                  RDoc::Text::encode_fallback('…', Encoding::UTF_8,    '...')
     assert_equal '...',
@@ -63,8 +61,6 @@ class TestRDocText < RDoc::TestCase
   end
 
   def test_expand_tabs_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     inn = "hello\ns\tdave"
     inn.force_encoding Encoding::BINARY
 
@@ -93,8 +89,6 @@ The comments associated with
   end
 
   def test_flush_left_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     text = <<-TEXT
 
   we don't worry too much.
@@ -303,8 +297,6 @@ paragraph will be cut off …
   end
 
   def test_strip_hashes_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     text = <<-TEXT
 ##
 # we don't worry too much.
@@ -338,8 +330,6 @@ paragraph will be cut off …
   end
 
   def test_strip_newlines_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     assert_equal Encoding::UTF_8, ''.encoding, 'Encoding sanity check'
 
     text = " \n"
@@ -389,8 +379,6 @@ paragraph will be cut off …
   end
 
   def test_strip_stars_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     text = <<-TEXT
 /*
  * * we don't worry too much.
@@ -415,8 +403,6 @@ paragraph will be cut off …
   end
 
   def test_strip_stars_encoding2
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     text = <<-TEXT
 /*
  * * we don't worry too much.
@@ -511,8 +497,6 @@ The comments associated with
   end
 
   def test_to_html_encoding
-    skip "Encoding not implemented" unless Object.const_defined? :Encoding
-
     s = '...(c)'.encode Encoding::Shift_JIS
 
     html = to_html s
@@ -555,4 +539,3 @@ The comments associated with
   end
 
 end
-


### PR DESCRIPTION
* Encoding class is always provided on Ruby 1.9 or later.
* String#byteslice is same as Encoding class.