### PR TITLE
fix an issue that rdoc fails when running on Windows with RUBYOPT=-U

### DIFF
--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -170,7 +170,7 @@ class RDoc::Generator::JsonIndex
     outfile           = out_dir + "#{search_index_file}.gz"
 
     debug_msg "Reading the JSON index file from %s" % search_index_file
-    search_index = open(search_index_file, 'r:utf-8', &:read)
+    search_index = search_index_file.read(mode: 'r:utf-8')
 
     debug_msg "Writing gzipped search index to %s" % outfile
 

--- a/lib/rdoc/generator/json_index.rb
+++ b/lib/rdoc/generator/json_index.rb
@@ -170,7 +170,7 @@ class RDoc::Generator::JsonIndex
     outfile           = out_dir + "#{search_index_file}.gz"
 
     debug_msg "Reading the JSON index file from %s" % search_index_file
-    search_index = search_index_file.read
+    search_index = open(search_index_file, 'r:utf-8', &:read)
 
     debug_msg "Writing gzipped search index to %s" % outfile
 

--- a/lib/rdoc/parser.rb
+++ b/lib/rdoc/parser.rb
@@ -78,7 +78,7 @@ class RDoc::Parser
 
     return true if s[0, 2] == Marshal.dump('')[0, 2] or s.index("\x00")
 
-    mode = "r"
+    mode = 'r:utf-8' # default source encoding has been chagened to utf-8
     s.sub!(/\A#!.*\n/, '')     # assume shebang line isn't longer than 1024.
     encoding = s[/^\s*\#\s*(?:-\*-\s*)?(?:en)?coding:\s*([^\s;]+?)(?:-\*-|[\s;])/, 1]
     mode = "rb:#{encoding}" if encoding
@@ -180,7 +180,9 @@ class RDoc::Parser
     return nil if /coding:/i =~ type
 
     type.downcase
-  rescue ArgumentError # invalid byte sequence, etc.
+  rescue ArgumentError
+  rescue Encoding::InvalidByteSequenceError # invalid byte sequence
+  
   end
 
   ##


### PR DESCRIPTION
rdoc sometimes failes when it runs on Windows with RUBYOPT=-U environment variable setting.

I confirmed this issue in following environment and process.
- Windows 10 Pro, **Japanese**
- ruby 2.3.1p112 (2016-04-26 revision 54768) [i386-mingw32]  
- rdoc 4.2.1 (pre-installed) and 5.0.0
- installing rroonga gem (6.1.0 x86-mingw32)  

"rdoc --debug" showed encoding errors, so I tried to fix this by
- add rescue Encoding::InvalidByteSequenceError in Rdoc::Parser.check_modeline
- specify encoding when reading a file in Rdoc::Parser.binary?
- specify encoding when reading a file in RDoc::Generator::JsonIndex#generate_gzipped

Regarding the first one, a change of open-mode to "rb" works fine too.
But this method has rescue line including a relevant comment, so I chose the above modification.

After this changes, rdoc works fine so far.
