### PR TITLE
Parse ruby 2.1 `<visibility> def` method definition

### DIFF
--- a/lib/rdoc/context.rb
+++ b/lib/rdoc/context.rb
@@ -99,6 +99,11 @@ class RDoc::Context < RDoc::CodeObject
   attr_accessor :visibility
 
   ##
+  # Current visibility of this line
+
+  attr_writer :current_line_visibility
+
+  ##
   # Hash of registered methods. Attributes are also registered here,
   # twice if they are RW.
 
@@ -148,6 +153,7 @@ class RDoc::Context < RDoc::CodeObject
     @extends     = []
     @constants   = []
     @external_aliases = []
+    @current_line_visibility = nil
 
     # This Hash maps a method name to a list of unmatched aliases (aliases of
     # a method not yet encountered).
@@ -478,7 +484,11 @@ class RDoc::Context < RDoc::CodeObject
       end
     else
       @methods_hash[key] = method
-      method.visibility = @visibility
+      if @current_line_visibility
+        method.visibility, @current_line_visibility = @current_line_visibility, nil
+      else
+        method.visibility = @visibility
+      end
       add_to @method_list, method
       resolve_aliases method
     end

--- a/lib/rdoc/parser/ruby.rb
+++ b/lib/rdoc/parser/ruby.rb
@@ -1666,6 +1666,7 @@ class RDoc::Parser::Ruby < RDoc::Parser
 
         unget_tk tk
         keep_comment = true
+        container.current_line_visibility = nil
 
       when TkCLASS then
         parse_class container, single, tk, comment
@@ -1888,6 +1889,8 @@ class RDoc::Parser::Ruby < RDoc::Parser
       #
     when TkNL, TkUNLESS_MOD, TkIF_MOD, TkSEMICOLON then
       container.ongoing_visibility = vis
+    when TkDEF
+      container.current_line_visibility = vis
     else
       update_visibility container, vis_type, vis, singleton
     end

--- a/test/test_rdoc_context.rb
+++ b/test/test_rdoc_context.rb
@@ -866,6 +866,27 @@ class TestRDocContext < XrefTestCase
     assert_equal [nil, 'Public', 'Internal'], titles
   end
 
+  def test_visibility_def
+    assert_equal :private, @c6.find_method_named('priv1').visibility
+    assert_equal :protected, @c6.find_method_named('prot1').visibility
+    assert_equal :public, @c6.find_method_named('pub1').visibility
+    assert_equal :private, @c6.find_method_named('priv2').visibility
+    assert_equal :protected, @c6.find_method_named('prot2').visibility
+    assert_equal :public, @c6.find_method_named('pub2').visibility
+    assert_equal :private, @c6.find_method_named('priv3').visibility
+    assert_equal :protected, @c6.find_method_named('prot3').visibility
+    assert_equal :public, @c6.find_method_named('pub3').visibility
+    assert_equal :private, @c6.find_method_named('priv4').visibility
+    assert_equal :protected, @c6.find_method_named('prot4').visibility
+    assert_equal :public, @c6.find_method_named('pub4').visibility
+    assert_equal :private, @c6.find_method_named('priv5').visibility
+    assert_equal :protected, @c6.find_method_named('prot5').visibility
+    assert_equal :public, @c6.find_method_named('pub5').visibility
+    assert_equal :private, @c6.find_method_named('priv6').visibility
+    assert_equal :protected, @c6.find_method_named('prot6').visibility
+    assert_equal :public, @c6.find_method_named('pub6').visibility
+  end
+
   def util_visibilities
     @pub  = RDoc::AnyMethod.new nil, 'pub'
     @prot = RDoc::AnyMethod.new nil, 'prot'

--- a/test/test_rdoc_store.rb
+++ b/test/test_rdoc_store.rb
@@ -162,7 +162,7 @@ class TestRDocStore < XrefTestCase
 
   def test_all_classes_and_modules
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6
       Child
       M1 M1::M2
       Parent
@@ -213,7 +213,7 @@ class TestRDocStore < XrefTestCase
 
   def test_classes
     expected = %w[
-      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1
+      C1 C2 C2::C3 C2::C3::H1 C3 C3::H1 C3::H2 C4 C4::C4 C5 C5::C1 C6
       Child
       Parent
     ]

--- a/test/xref_data.rb
+++ b/test/xref_data.rb
@@ -57,6 +57,31 @@ class C5
   end
 end
 
+class C6
+  private def priv1() end
+  def pub1() end
+  protected def prot1() end
+  def pub2() end
+  public def pub3() end
+  def pub4() end
+
+  private
+  private def priv2() end
+  def priv3() end
+  protected def prot2() end
+  def priv4() end
+  public def pub5() end
+  def priv5() end
+
+  protected
+  private def priv6() end
+  def prot3() end
+  protected def prot4() end
+  def prot5() end
+  public def pub6() end
+  def prot6() end
+end
+
 module M1
   def m
   end

--- a/test/xref_test_case.rb
+++ b/test/xref_test_case.rb
@@ -51,6 +51,7 @@ class XrefTestCase < RDoc::TestCase
     @c5_c1 = @xref_data.find_module_named 'C5::C1'
     @c3_h1 = @xref_data.find_module_named 'C3::H1'
     @c3_h2 = @xref_data.find_module_named 'C3::H2'
+    @c6    = @xref_data.find_module_named 'C6'
 
     @m1    = @xref_data.find_module_named 'M1'
     @m1_m  = @m1.method_list.first


### PR DESCRIPTION
This patch adds an ability to parse ruby 2.1 style `private def foo()` method definition.

I suppose test/test_rdoc_context.rb is not the right place to put a test code for this, and also test/xref_data.rb may not be the right place to put the test data.
I'm willing to fix them if anyone can tell me where to put them.

fixes #355 #354