### PR TITLE
Suppress warnings in eval

### DIFF
--- a/lib/rdoc/markup/to_html.rb
+++ b/lib/rdoc/markup/to_html.rb
@@ -383,9 +383,12 @@ class RDoc::Markup::ToHtml < RDoc::Markup::Formatter
   # Returns true if text is valid ruby syntax
 
   def parseable? text
+    verbose, $VERBOSE = $VERBOSE, nil
     eval("BEGIN {return true}\n#{text}")
   rescue SyntaxError
     false
+  ensure
+    $VERBOSE = verbose
   end
 
   ##


### PR DESCRIPTION
The argument text may contain warnings, which are useless to check
if parseable.