### PR TITLE
Run benchmark only when ENV['BENCHMARK'] == 'yes'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-ENV['BENCHMARK'] = 'yes'
+ENV['BENCHMARK'] ||= 'yes'
 
 task :docs    => :generate
 task :test    => :generate

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -6,7 +6,7 @@ rescue NoMethodError, Gem::LoadError
 end
 
 require 'minitest/autorun'
-require 'minitest/benchmark' if ENV['BENCHMARK']
+require 'minitest/benchmark' if ENV['BENCHMARK'] == 'yes'
 
 require 'fileutils'
 require 'pp'


### PR DESCRIPTION
The test suite of RDoc has [a benchmark test](https://github.com/rdoc/rdoc/blob/7b660d057677ed6b2a13766ac561237b22ed0ff6/test/test_rdoc_context.rb#L413). The benchmark test is run [when `ENV['BENCHMARK']` is set](https://github.com/rdoc/rdoc/blob/1a876cf6653545eb27810f827eb671b9c1916baa/lib/rdoc/test_case.rb#L9), but [`Rakefile` locks `ENV['BENCHMARK']` is `'yes'`](https://github.com/rdoc/rdoc/blob/c06cb00e86ee94e013e34fe27838f730ae94e8f0/Rakefile#L6). Nobody can change whether to run benchmark. This won't serve the purpose.

This Pull Request serves new behavior:

- Run benchmark test only when `ENV['BENCHMARK']` is `'yes'`
- `Rakefile` sets `ENV['BENCHMARK']` as `'yes'` only when `ENV['BENCHMARK']` isn't set

The benchmark test runs with `rake`. The benchmark test doesn't run with `BENCHMARK=no rake`.

This is for avoidance of [dependence on CI circumstances](https://ci.appveyor.com/project/ruby/rdoc/build/1.0.2/job/7seut6qphmds9fqf).