### PR TITLE
Use NOBENCHMARK env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ rvm:
   - rbx-2
   - jruby-1.7.25
   - jruby-9.1.0.0
+env:
+  global:
+    NOBENCHMARK=1
 script: rake
 matrix:
   allow_failures:

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require 'rdoc/task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
-ENV['BENCHMARK'] = 'yes'
-
 task :docs    => :generate
 task :test    => :generate
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ test_script:
   - rake
 deploy: off
 environment:
+  NOBENCHMARK: 1
   matrix:
     - ruby_version: "193"
     - ruby_version: "200"

--- a/lib/rdoc/test_case.rb
+++ b/lib/rdoc/test_case.rb
@@ -6,7 +6,7 @@ rescue NoMethodError, Gem::LoadError
 end
 
 require 'minitest/autorun'
-require 'minitest/benchmark' if ENV['BENCHMARK']
+require 'minitest/benchmark' unless ENV['NOBENCHMARK']
 
 require 'fileutils'
 require 'pp'


### PR DESCRIPTION
This Pull Request is modified versions of https://github.com/rdoc/rdoc/pull/446 what was not refined.

The command `rake` runs tests with benchmark:

```bash
$ rake
Run options: --seed 35482

# Running tests:

......(snip)......

Finished tests in 13.490933s, 159.9593 tests/s, 381.0707 assertions/s.

2158 tests, 5141 assertions, 0 failures, 0 errors, 1 skips

# Running benchmarks:


TestRDocContext 1       10      100     1000    10000
bench_add_include        0.000037        0.000052        0.000288        0.003270        0.020100


Finished benchmarks in 0.084059s, 11.8964 tests/s, 11.8964 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 1 skips
```

The `NOBENCHMARK=1 rake` runs tests without benchmark:

```bash
$ NOBENCHMARK=1 rake
Run options: --seed 274

# Running tests:

......(snip)......

Finished tests in 21.829784s, 98.8558 tests/s, 235.5039 assertions/s.

2158 tests, 5141 assertions, 0 failures, 0 errors, 1 skips
```

This is easily understandable.