### PR TITLE
Remove unused use_cache default option for ri

### DIFF
--- a/lib/rdoc/ri/driver.rb
+++ b/lib/rdoc/ri/driver.rb
@@ -80,7 +80,6 @@ class RDoc::RI::Driver
     options[:interactive] = false
     options[:profile]     = false
     options[:show_all]    = false
-    options[:use_cache]   = true
     options[:use_stdout]  = !$stdout.tty?
     options[:width]       = 72
 


### PR DESCRIPTION
A tiny fix,
the corresponding ri --[no-]use-cache option was removed
long ago (Nov 2009), with 390a0707273528c5ae6c38b0b21ea081df06d27b.