### PR TITLE
Update to latest versions of Ruby 2.2, 2.3, JRuby 1.7 and 9k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
   - 2.4.1
   - ruby-head
   - rbx-2
-  - jruby-1.7.25
-  - jruby-9.1.0.0
+  - jruby-1.7.26
+  - jruby-9.1.9.0
 env:
   global:
     NOBENCHMARK=1
 script: rake
 matrix:
   allow_failures:
-    - rvm: jruby-1.7.25
-    - rvm: jruby-9.1.0.0
+    - rvm: jruby-1.7.26
+    - rvm: jruby-9.1.9.0
     - rvm: rbx-2


### PR DESCRIPTION
[JRuby 9.1.10.0](http://jruby.org/2017/05/25/jruby-9-1-10-0.html) and [JRuby 1.7.27](http://jruby.org/2017/05/11/jruby-1-7-27) have been released, but there are not in list of ["Travis CI: Precompiled Ruby Versions"](http://rubies.travis-ci.org/). So I added `jruby-9.1.9.0` and `jruby-1.7.26` what are in the list now.