### PR TITLE
Add ruby_version 24 and 24-x64 to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,3 +19,5 @@ environment:
     - ruby_version: "22-x64"
     - ruby_version: "23"
     - ruby_version: "23-x64"
+    - ruby_version: "24"
+    - ruby_version: "24-x64"


### PR DESCRIPTION
AppVeyor [supports Ruby 2.4.1-1](https://www.appveyor.com/updates/2017/06/12/) with RubyInstaller2 ([discussed on a GitHub issue](https://github.com/appveyor/ci/issues/1350)). It's listed on [Build Environment page of AppVeyor](https://www.appveyor.com/docs/build-environment/#ruby).