### PR TITLE
Add test for require dynamic string

### DIFF
--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -2390,6 +2390,20 @@ end
     assert_equal :private, date_time_now.visibility, date_time_now.full_name
   end
 
+  def test_parse_require_dynamic_string
+    content = <<-RUBY
+prefix = 'path'
+require "\#{prefix}/a_library"
+require 'test'
+RUBY
+
+    util_parser content
+
+    @parser.parse_statements @top_level
+
+    assert_equal 1, @top_level.requires.length
+  end
+
   def test_parse_statements_identifier_require
     content = "require 'bar'"
 


### PR DESCRIPTION
The require dynamic string like below shouldn't be parsed:

``` ruby
prefix = 'path'
require "#{prefix}/a_library"
```