### PR TITLE
 Add test for postfix if/unless/while/until

### DIFF
--- a/test/test_rdoc_parser_ruby.rb
+++ b/test/test_rdoc_parser_ruby.rb
@@ -1991,6 +1991,30 @@ end
     assert_equal 'Foo#blah', methods.first.full_name
   end
 
+  def test_parse_statements_postfix_if_unless
+    util_parser <<-CODE
+class C
+  def foo
+    1 if nil
+  end
+
+  def bar
+    2 unless nil
+  end
+end
+    CODE
+
+    @parser.parse_statements @top_level, RDoc::Parser::Ruby::NORMAL, nil
+
+    c = @top_level.classes.first
+    assert_equal 'C', c.full_name, 'class C'
+
+    methods = c.method_list
+    assert_equal 2, methods.length
+    assert_equal 'C#foo', methods[0].full_name
+    assert_equal 'C#bar', methods[1].full_name
+  end
+
   def test_parse_statements_class_nested
     comment = RDoc::Comment.new "##\n# my method\n", @top_level
 


### PR DESCRIPTION
The postfix form for `if`/`unless`/`while`/`until` is detected in IRB Ruby parser with special token types of `TkIF_MOD`/`TkUNLESS_MOD`/`TkWHILE_MOD`/`TkUNTIL_MOD`, but the detection is a new feature in `parser.y` after parsed with `EXPR_LABEL` bit, it's introduced after the birth of IRB.

So this is an important test to replace Ruby parser of IRB with Ripper.