### PR TITLE
Support rational and imaginary

### DIFF
--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -1125,6 +1125,7 @@ class RDoc::RubyLex
     type = TkINTEGER
     allow_point = true
     allow_e = true
+    allow_ri = true
     non_digit = false
     while ch = getc
       num << ch
@@ -1154,8 +1155,25 @@ class RDoc::RubyLex
           num << getc
         end
         allow_e = false
+        allow_ri = false
         allow_point = false
         non_digit = ch
+      when allow_ri && "r"
+        if non_digit
+          raise Error, "trailing `#{non_digit}' in number"
+        end
+        type = TkRATIONAL
+        if peek(0) == 'i'
+          type = TkIMAGINARY
+          num << getc
+        end
+        break
+      when allow_ri && "i"
+        if non_digit && non_digit != "r"
+          raise Error, "trailing `#{non_digit}' in number"
+        end
+        type = TkIMAGINARY
+        break
       else
         if non_digit
           raise Error, "trailing `#{non_digit}' in number"

--- a/lib/rdoc/ruby_token.rb
+++ b/lib/rdoc/ruby_token.rb
@@ -331,6 +331,8 @@ module RDoc::RubyToken
 
     [:TkINTEGER,    TkVal],
     [:TkFLOAT,      TkVal],
+    [:TkRATIONAL,   TkVal],
+    [:TkIMAGINARY,  TkVal],
     [:TkSTRING,     TkVal],
     [:TkHEREDOC,    TkVal],
     [:TkXSTRING,    TkVal],

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -418,5 +418,24 @@ U
     assert_equal("-0.1", ruby_lex.token.value)
   end
 
+  def test_rational_imaginary_tokenize
+    tokens = RDoc::RubyLex.tokenize '1.11r + 2.34i + 5.55ri', nil
+
+    expected = [
+      @TK::TkRATIONAL .new( 0, 1,  0, '1.11r'),
+      @TK::TkSPACE    .new( 5, 1,  5, ' '),
+      @TK::TkPLUS     .new( 6, 1,  6, '+'),
+      @TK::TkSPACE    .new( 7, 1,  7, ' '),
+      @TK::TkIMAGINARY.new( 8, 1,  8, '2.34i'),
+      @TK::TkSPACE    .new(13, 1, 13, ' '),
+      @TK::TkPLUS     .new(14, 1, 14, '+'),
+      @TK::TkSPACE    .new(15, 1, 15, ' '),
+      @TK::TkIMAGINARY.new(16, 1, 16, '5.55ri'),
+      @TK::TkNL       .new(22, 1, 22, "\n"),
+    ]
+
+    assert_equal expected, tokens
+  end
+
 end
 


### PR DESCRIPTION
In RDoc for CRuby, syntax highlight of `BigDecimal` is broken:

![before PR](https://i.gyazo.com/500e6a0e3d45aca7d2ea8b5e854db462.png)

RDoc splits to `3` and `r` as different tokens when parsing rational literal `3r`.

This Pull Request fixes it like below:

![after PR](https://i.gyazo.com/e38423fd5af8e43af0805c369e43459f.png)

RDoc detects `3r` as one rational token.