### PR TITLE
Move collecting up tokens for a symbol to RubyLex

### DIFF
--- a/lib/rdoc/parser/ruby_tools.rb
+++ b/lib/rdoc/parser/ruby_tools.rb
@@ -33,26 +33,6 @@ module RDoc::Parser::RubyTools
 
     tk = nil if TkEND_OF_SCRIPT === tk
 
-    if TkSYMBEG === tk then
-      set_token_position tk.line_no, tk.char_no
-
-      case tk1 = get_tk
-      when TkId, TkOp, TkSTRING, TkDSTRING, TkSTAR, TkAMPER then
-        if tk1.respond_to?(:name) then
-          tk = Token(TkSYMBOL).set_text(":" + tk1.name)
-        else
-          tk = Token(TkSYMBOL).set_text(":" + tk1.text)
-        end
-
-        # remove the identifier we just read to replace it with a symbol
-        @token_listeners.each do |obj|
-          obj.pop_token
-        end if @token_listeners
-      else
-        tk = tk1
-      end
-    end
-
     # inform any listeners of our shiny new token
     @token_listeners.each do |obj|
       obj.add_token(tk)

--- a/lib/rdoc/ruby_lex.rb
+++ b/lib/rdoc/ruby_lex.rb
@@ -361,6 +361,22 @@ class RDoc::RubyLex
     if @readed_auto_clean_up
       get_readed
     end
+
+    if TkSYMBEG === tk then
+      tk1 = token
+      set_token_position tk.line_no, tk.char_no
+
+      case tk1
+      when TkId, TkOp, TkSTRING, TkDSTRING, TkSTAR, TkAMPER then
+        if tk1.respond_to?(:name) then
+          tk = Token(TkSYMBOL, ":" + tk1.name)
+        else
+          tk = Token(TkSYMBOL, ":" + tk1.text)
+        end
+      else
+        tk = tk1
+      end
+    end
     #      Tracer.off
     tk
   end

--- a/test/test_rdoc_ruby_lex.rb
+++ b/test/test_rdoc_ruby_lex.rb
@@ -81,8 +81,7 @@ end
       @TK::TkLBRACE    .new( 0, 1,  0, '{'),
       @TK::TkSPACE     .new( 1, 1,  1, ' '),
       @TK::TkIDENTIFIER.new( 2, 1,  2, 'class'),
-      @TK::TkSYMBEG    .new( 7, 1,  7, ':'),
-      @TK::TkSTRING    .new( 8, 1,  8, '"foo"'),
+      @TK::TkSYMBOL    .new( 7, 1,  7, ':"foo"'),
       @TK::TkSPACE     .new(13, 1, 13, ' '),
       @TK::TkRBRACE    .new(14, 1, 14, '}'),
       @TK::TkNL        .new(15, 1, 15, "\n"),
@@ -393,8 +392,7 @@ U
       @TK::TkIDENTIFIER.new( 6, 1,  6, 'module'),
       @TK::TkCOLON     .new(12, 1, 12, ':'),
       @TK::TkSPACE     .new(13, 1, 13, ' '),
-      @TK::TkSYMBEG    .new(14, 1, 14, ':'),
-      @TK::TkIDENTIFIER.new(15, 1, 15, 'v1'),
+      @TK::TkSYMBOL    .new(14, 1, 14, ':v1'),
       @TK::TkNL        .new(17, 1, 17, "\n"),
     ]
 


### PR DESCRIPTION
`RDoc::Markup::ToHtml` uses `RDoc::RubyLex.tokenize` directly and calls `RDoc::TokenStream.to_html` with returned tokens.

On the one hand, `RDoc::Parser::RubyTools#get_tk` collects up `TkSYMBEG` and trailing tokens inside the symbol with tokens by `RDoc::RubyLex`.

I moved logic what collects up tokens for a symbol from `RDoc::Parser::RubyTools#get_tk` to `RDoc::RubyLex`. So `RDoc::TokenStream.to_html` becomes to handle symbols as value.

Before, each symbols are separeted `TkSYMBEG` and trailing tokens:

![separeted symbol](https://i.gyazo.com/14e2a9f81be8a586d152a020503f10c1.png)

``` html
<pre class="ruby">
<span class="ruby-identifier">a</span> = :<span class="ruby-identifier">hoge</span>
</pre>
```

I think what `:` and `hoge` with `ruby-identifier` attribute are separeted is not correct because symbol is one literal and one value. It's not identifier.

After, each symbols are treated as literal with `ruby-value` attribute.

![collected up symbol](https://i.gyazo.com/b136c84749cd728a3139500861c2e6a4.png)

``` html
<pre class="ruby">
<span class="ruby-identifier">a</span> = <span class="ruby-value">:hoge</span>
</pre>
```
